### PR TITLE
Dynamic document titles

### DIFF
--- a/web/src/components/BuildPage.vue
+++ b/web/src/components/BuildPage.vue
@@ -58,10 +58,12 @@
 <script>
 import BuildsAPI from '@/utils/api/builds';
 import ErrorsMixin from '@/mixins/Errors';
+import BuildsMixin from '@/mixins/Builds';
+import { DEFAULT_DOCUMENT_TITLE } from '@/store/constants';
 
 export default {
   name: 'build-page',
-  mixins: [ErrorsMixin],
+  mixins: [ErrorsMixin, BuildsMixin],
   data() {
     return {
       build: null,
@@ -90,7 +92,12 @@ export default {
       } else {
         this.build = build.data;
         this.error = false;
+        this.updateDocumentTitle();
       }
+    },
+    updateDocumentTitle() {
+      const cpu = this.cleanCPU(this.build.cpu);
+      document.title = `Build Details - ${cpu} - ${DEFAULT_DOCUMENT_TITLE}`;
     },
   },
 };

--- a/web/src/components/BuildPage.vue
+++ b/web/src/components/BuildPage.vue
@@ -97,7 +97,7 @@ export default {
     },
     updateDocumentTitle() {
       const cpu = this.cleanCPU(this.build.cpu);
-      document.title = `Build Details - ${cpu} - ${DEFAULT_DOCUMENT_TITLE}`;
+      document.title = `Build Details | ${cpu} | ${DEFAULT_DOCUMENT_TITLE}`;
     },
   },
 };

--- a/web/src/components/BuildsPage.vue
+++ b/web/src/components/BuildsPage.vue
@@ -41,10 +41,11 @@
 <script>
 import BuildsAPI from '@/utils/api/builds';
 import ErrorsMixin from '@/mixins/Errors';
+import BuildsMixin from '@/mixins/Builds';
 
 export default {
   name: 'builds-page',
-  mixins: [ErrorsMixin],
+  mixins: [ErrorsMixin, BuildsMixin],
   data() {
     return {
       builds: null,
@@ -62,9 +63,6 @@ export default {
       } else {
         this.builds = builds.data.items;
       }
-    },
-    cleanCPU(cpu) {
-      return cpu.split('@')[0].trim();
     },
   },
 };

--- a/web/src/components/ProjectPage.vue
+++ b/web/src/components/ProjectPage.vue
@@ -135,6 +135,7 @@ import ErrorsMixin from '@/mixins/Errors';
 import '@/assets/images/icons/generated/github';
 import '@/assets/images/icons/generated/link-external';
 import '@/assets/images/icons/generated/play';
+import { DEFAULT_DOCUMENT_TITLE } from '@/store/constants';
 
 export default {
   name: 'project-page',
@@ -167,7 +168,11 @@ export default {
       } else {
         this.project = project.data;
         this.error = false;
+        this.updateDocumentTitle();
       }
+    },
+    updateDocumentTitle() {
+      document.title = `Project Details - ${this.project.title} - ${DEFAULT_DOCUMENT_TITLE}`;
     },
     showGIF(which) {
       const gif = this.$refs[which][0];

--- a/web/src/components/ProjectPage.vue
+++ b/web/src/components/ProjectPage.vue
@@ -172,7 +172,7 @@ export default {
       }
     },
     updateDocumentTitle() {
-      document.title = `Project Details - ${this.project.title} - ${DEFAULT_DOCUMENT_TITLE}`;
+      document.title = `Project Details | ${this.project.title} | ${DEFAULT_DOCUMENT_TITLE}`;
     },
     showGIF(which) {
       const gif = this.$refs[which][0];

--- a/web/src/components/dashboard/DashboardHome.vue
+++ b/web/src/components/dashboard/DashboardHome.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="content">
-    <div class="section-header section-header-size">{{ getTitle() }}</div>
+    <div class="section-header section-header-size">{{ title }}</div>
 
     <div class="content-text">
       <div class="dashboard-nav">
@@ -31,10 +31,23 @@ import { API_TOKEN_KEY } from '@/store/constants';
 export default {
   name: 'dashboard-home',
   mixins: [ErrorsMixin],
-  methods: {
-    getTitle() {
-      return document.title;
+  data() {
+    return {
+      title: null,
+    };
+  },
+  watch: {
+    $route: {
+      immediate: true,
+      handler(to) {
+        const parts = to.meta.title.split('|');
+        parts.pop();
+
+        this.title = parts.map((s) => s.trim()).join(' - ');
+      },
     },
+  },
+  methods: {
     logout() {
       AuthAPI.logout(this.$cookie.get(API_TOKEN_KEY))
         .then(() => {

--- a/web/src/mixins/Builds.js
+++ b/web/src/mixins/Builds.js
@@ -1,0 +1,7 @@
+export default {
+  methods: {
+    cleanCPU(cpu) {
+      return cpu.split('@')[0].trim();
+    },
+  },
+};

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -77,7 +77,8 @@ const router = new VueRouter({
       component: ProjectPage,
       meta: {
         secure: false,
-        title: `Project Details - ${defaultTitle}`,
+        title: (route) =>
+          `Project ${route.params.id} Details - ${defaultTitle}`,
       },
     },
     {
@@ -93,7 +94,7 @@ const router = new VueRouter({
       component: BuildPage,
       meta: {
         secure: false,
-        title: `Build Details - ${defaultTitle}`,
+        title: (route) => `Build ${route.params.id} Details - ${defaultTitle}`,
       },
     },
     {
@@ -151,7 +152,7 @@ const router = new VueRouter({
       component: NotFoundPage,
       meta: {
         secure: false,
-        title: defaultTitle,
+        title: `404 - ${defaultTitle}`,
       },
     },
   ],
@@ -159,9 +160,6 @@ const router = new VueRouter({
 
 router.beforeEach(async (to, from, next) => {
   let match, authorized;
-
-  // Update the HTML title
-  document.title = to.meta.title;
 
   // Checking if valid cookie exists, skips login if true
   if (to.fullPath === '/login') {
@@ -197,6 +195,13 @@ router.beforeEach(async (to, from, next) => {
   } else {
     next();
   }
+});
+
+router.afterEach((to) => {
+  Vue.nextTick(() => {
+    document.title =
+      typeof to.meta.title === 'function' ? to.meta.title(to) : to.meta.title;
+  });
 });
 
 export default router;

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -28,12 +28,12 @@ const formatPageTitle = (name) => {
 };
 
 const formatDashboardTitle = (name) => {
-  // Capitalize each word and surround hyphens with spaces
+  // Capitalize each word and surround pipes with spaces
   return name
     .toLowerCase()
     .split('-')
     .map((s) => s.charAt(0).toUpperCase() + s.substring(1))
-    .join(' - ');
+    .join(' | ');
 };
 
 const router = new VueRouter({
@@ -59,7 +59,7 @@ const router = new VueRouter({
       component: ResumePage,
       meta: {
         secure: false,
-        title: `Résumé - ${DEFAULT_DOCUMENT_TITLE}`,
+        title: `Résumé | ${DEFAULT_DOCUMENT_TITLE}`,
       },
     },
     {
@@ -67,7 +67,7 @@ const router = new VueRouter({
       component: ProjectsPage,
       meta: {
         secure: false,
-        title: `Projects - ${DEFAULT_DOCUMENT_TITLE}`,
+        title: `Projects | ${DEFAULT_DOCUMENT_TITLE}`,
       },
     },
     {
@@ -83,7 +83,7 @@ const router = new VueRouter({
       component: BuildsPage,
       meta: {
         secure: false,
-        title: `Builds - ${DEFAULT_DOCUMENT_TITLE}`,
+        title: `Builds | ${DEFAULT_DOCUMENT_TITLE}`,
       },
     },
     {
@@ -99,7 +99,7 @@ const router = new VueRouter({
       component: LoginPage,
       meta: {
         secure: false,
-        title: formatPageTitle(LoginPage.name),
+        title: `${formatPageTitle(LoginPage.name)} | ${DEFAULT_DOCUMENT_TITLE}`,
       },
     },
     {
@@ -107,7 +107,9 @@ const router = new VueRouter({
       component: DashboardHome,
       meta: {
         secure: true,
-        title: formatDashboardTitle(DashboardHome.name),
+        title: `${formatDashboardTitle(
+          DashboardHome.name,
+        )} | ${DEFAULT_DOCUMENT_TITLE}`,
       },
       children: [
         {
@@ -115,7 +117,9 @@ const router = new VueRouter({
           component: DashboardImages,
           meta: {
             secure: true,
-            title: formatDashboardTitle(DashboardImages.name),
+            title: `${formatDashboardTitle(
+              DashboardImages.name,
+            )} | ${DEFAULT_DOCUMENT_TITLE}`,
           },
         },
         {
@@ -123,7 +127,9 @@ const router = new VueRouter({
           component: DashboardBuilds,
           meta: {
             secure: true,
-            title: formatDashboardTitle(DashboardBuilds.name),
+            title: `${formatDashboardTitle(
+              DashboardBuilds.name,
+            )} | ${DEFAULT_DOCUMENT_TITLE}`,
           },
         },
         {
@@ -131,7 +137,9 @@ const router = new VueRouter({
           component: DashboardProjects,
           meta: {
             secure: true,
-            title: formatDashboardTitle(DashboardProjects.name),
+            title: `${formatDashboardTitle(
+              DashboardProjects.name,
+            )} | ${DEFAULT_DOCUMENT_TITLE}`,
           },
         },
         {
@@ -139,7 +147,9 @@ const router = new VueRouter({
           component: DashboardAccount,
           meta: {
             secure: true,
-            title: formatDashboardTitle(DashboardAccount.name),
+            title: `${formatDashboardTitle(
+              DashboardAccount.name,
+            )} | ${DEFAULT_DOCUMENT_TITLE}`,
           },
         },
       ],
@@ -149,7 +159,7 @@ const router = new VueRouter({
       component: NotFoundPage,
       meta: {
         secure: false,
-        title: `404 - ${DEFAULT_DOCUMENT_TITLE}`,
+        title: `404 | ${DEFAULT_DOCUMENT_TITLE}`,
       },
     },
   ],

--- a/web/src/router/index.js
+++ b/web/src/router/index.js
@@ -14,11 +14,9 @@ import DashboardBuilds from '@/components/dashboard/DashboardBuilds';
 import DashboardProjects from '@/components/dashboard/DashboardProjects';
 import DashboardAccount from '@/components/dashboard/DashboardAccount';
 import NotFoundPage from '@/components/NotFoundPage';
-import { API_TOKEN_KEY } from '@/store/constants';
+import { API_TOKEN_KEY, DEFAULT_DOCUMENT_TITLE } from '@/store/constants';
 
 Vue.use(VueRouter);
-
-const defaultTitle = 'Chris Meyers - Developer, Tech Enthusiast';
 
 const formatPageTitle = (name) => {
   // Remove hyphens and "page"
@@ -53,7 +51,7 @@ const router = new VueRouter({
       component: AboutPage,
       meta: {
         secure: false,
-        title: defaultTitle,
+        title: DEFAULT_DOCUMENT_TITLE,
       },
     },
     {
@@ -61,7 +59,7 @@ const router = new VueRouter({
       component: ResumePage,
       meta: {
         secure: false,
-        title: `Résumé - ${defaultTitle}`,
+        title: `Résumé - ${DEFAULT_DOCUMENT_TITLE}`,
       },
     },
     {
@@ -69,7 +67,7 @@ const router = new VueRouter({
       component: ProjectsPage,
       meta: {
         secure: false,
-        title: `Projects - ${defaultTitle}`,
+        title: `Projects - ${DEFAULT_DOCUMENT_TITLE}`,
       },
     },
     {
@@ -77,8 +75,7 @@ const router = new VueRouter({
       component: ProjectPage,
       meta: {
         secure: false,
-        title: (route) =>
-          `Project ${route.params.id} Details - ${defaultTitle}`,
+        title: false,
       },
     },
     {
@@ -86,7 +83,7 @@ const router = new VueRouter({
       component: BuildsPage,
       meta: {
         secure: false,
-        title: `Builds - ${defaultTitle}`,
+        title: `Builds - ${DEFAULT_DOCUMENT_TITLE}`,
       },
     },
     {
@@ -94,7 +91,7 @@ const router = new VueRouter({
       component: BuildPage,
       meta: {
         secure: false,
-        title: (route) => `Build ${route.params.id} Details - ${defaultTitle}`,
+        title: false,
       },
     },
     {
@@ -152,7 +149,7 @@ const router = new VueRouter({
       component: NotFoundPage,
       meta: {
         secure: false,
-        title: `404 - ${defaultTitle}`,
+        title: `404 - ${DEFAULT_DOCUMENT_TITLE}`,
       },
     },
   ],
@@ -199,8 +196,9 @@ router.beforeEach(async (to, from, next) => {
 
 router.afterEach((to) => {
   Vue.nextTick(() => {
-    document.title =
-      typeof to.meta.title === 'function' ? to.meta.title(to) : to.meta.title;
+    if (to.meta.title !== false) {
+      document.title = to.meta.title;
+    }
   });
 });
 

--- a/web/src/store/constants.js
+++ b/web/src/store/constants.js
@@ -8,3 +8,5 @@ export const MOBILE_BREAKPOINT = 970; // px
 export const MAILTO_HREF =
   'mailto:chris@chrismeyers.info?subject=Message%20from%20chrismeyers.info';
 export const SYSTEM_THEME_DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+export const DEFAULT_DOCUMENT_TITLE =
+  'Chris Meyers - Developer, Tech Enthusiast';


### PR DESCRIPTION
There's a minor bug in the latest version of macOS Chrome and Safari when navigating between different instances of the same component (ex: `/builds/1` to `/builds/2`) using the `cd` prompt command.  The title of the current browser history entry will be the same as the previous browser history entry, even though the URLs in each browser history entry are (correctly) different.

I tested this in the latest version of macOS Firefox and the title in the browser history is updating as expected.